### PR TITLE
fix(sql): Sort columns alphabetically so that it works properly

### DIFF
--- a/src/test/kotlin/net/dzikoysk/exposed/upsert/spec/StatisticsRepository.kt
+++ b/src/test/kotlin/net/dzikoysk/exposed/upsert/spec/StatisticsRepository.kt
@@ -52,6 +52,7 @@ internal class StatisticsRepository {
         val httpMethod: Column<String> = varchar("http_method", 32)
         val uri: Column<String> = varchar("uri", 512)
         val count: Column<Long> = long("count")
+        val lastUpdated: Column<Long> = long("last_updated") // you would probably use DateTime for this but this is easier
 
         val typeIndex = withIndex("index_type", columns = arrayOf(httpMethod))
         val uniqueTypeValue = withUnique("unique_http_method_to_uri", httpMethod, uri)
@@ -68,7 +69,8 @@ internal class StatisticsRepository {
         override val id: Int = UNINITIALIZED_ENTITY_ID,
         val httpMethod: String,
         val uri: String,
-        val count: Long
+        val count: Long,
+        val lastUpdated: Long = 0
     ) : IdentifiableEntity {
 
         override fun toString() = "$id | $httpMethod | $uri | $count"
@@ -91,6 +93,7 @@ internal class StatisticsRepository {
                     it[this.httpMethod] = record.httpMethod
                     it[this.uri] = record.uri
                     it[this.count] = record.count
+                    it[this.lastUpdated] = record.lastUpdated
                 },
                 updateBody = {
                     with(SqlExpressionBuilder) {
@@ -119,7 +122,8 @@ internal class StatisticsRepository {
             id = row[StatisticsTable.id].value,
             httpMethod = row[StatisticsTable.httpMethod],
             uri = row[StatisticsTable.uri],
-            count = row[StatisticsTable.count]
+            count = row[StatisticsTable.count],
+            lastUpdated = row[StatisticsTable.lastUpdated]
         )
 
 }

--- a/src/test/kotlin/net/dzikoysk/exposed/upsert/spec/UpsertSpecification.kt
+++ b/src/test/kotlin/net/dzikoysk/exposed/upsert/spec/UpsertSpecification.kt
@@ -81,25 +81,30 @@ internal open class UpsertSpecification {
         statisticsRepository.findAll().forEach { println(it) }
 
         // should reset count and change URI
-        statisticsRepository.findAll().forEach { record ->
-            transaction {
-                StatisticsTable.upsert(conflictIndex = StatisticsTable.uniqueTypeValue,
-                    insertBody = {
-                        // this is technically irrelevant
-                        it[this.httpMethod] = record.httpMethod
-                        it[this.uri] = record.uri
-                        it[this.count] = record.count
-                    },
-                    updateBody = {
-                        it[this.uri] = record.uri.replace("xyz", "abc")
-                        it[this.count] = 1
-                    }
-                )
+        val records = statisticsRepository.findAll()
+        if (!records.isEmpty()) {
+            for (record in records) {
+                val value = transaction {
+                    StatisticsTable.upsert(conflictIndex = StatisticsTable.uniqueTypeValue,
+                        insertBody = {
+                            // this is technically irrelevant
+                            // it[this.id] = record.id
+                            it[this.httpMethod] = record.httpMethod
+                            it[this.uri] = record.uri
+                            it[this.count] = record.count
+                            it[this.lastUpdated] = record.lastUpdated
+                        },
+                        updateBody = {
+                            // intentionally ordered in reverse
+                            it[this.lastUpdated] = record.lastUpdated + 100 // something predictable
+                            it[this.count] = 1
+                        }
+                    )
+                    statisticsRepository.findByTypeAndValue(record.httpMethod, record.uri)
+                }
+                assertEquals(record.lastUpdated + 100, value.lastUpdated)
+                assertEquals(1, value.count)
             }
         }
-
-        assertEquals(1, statisticsRepository.upsertRecord(Record(1, "GET", "/abc", 0)).count)
-        assertEquals(1, statisticsRepository.upsertRecord(Record(2, "GET", "/abc/abc", 0)).count)
-        assertEquals(1, statisticsRepository.upsertRecord(Record(3, "POST", "/abc/abc", 0)).count)
     }
 }


### PR DESCRIPTION
There's a very specific bug with this library - the `DO UPDATE SET` part of the generated query has the fields ordered as the user specified them, whereas the replacement is set based on the key (i.e. they're alphabetically ordered).
This PR just fixes that bug, plus makes that subset of the code slightly more maintainable.

I am not entirely sure if this has introduced another bug or not, but it seems to work so it's probably fine.